### PR TITLE
Added a CI workflow that runs the examples

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        matplotlib: ["matplotlib==3.4.0", "matplotlib==3.5.0", "matplotlib==3.6.0", "matplotlib==3.7.0"]
+        matplotlib: ["matplotlib==3.5.0", "matplotlib==3.6.0", "matplotlib==3.7.0"]
         seaborn: ["seaborn==0.13.0"]
     steps:
     - name: Checkout repository

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        matplotlib-version: ["3.6.0", "3.7.0", "3.8.0", "3.9.0"]
-        seaborn-version: ["0.13.0"]
+        matplotlib-version: ["matplotlib==3.6.0", "matplotlib==3.7.0", "matplotlib==3.8.0", "matplotlib==3.9.0"]
+        seaborn-version: ["seaborn==0.13.0"]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -36,9 +36,9 @@ jobs:
         # Install starbars
         pip install -e .[test]
         # Install matplotlib
-        pip install matplotlib==${{ matrix.matplotlib-version }}
+        pip install ${{ matrix.matplotlib }}
         # Install seaborn
-        pip install seaborn==${{ matrix.seaborn-version }}
+        pip install ${{ matrix.seaborn }}
 
     - name: Run tests & coverage
       run: pytest --cov=starbars

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,6 +39,8 @@ jobs:
         pip install ${{ matrix.matplotlib }}
         # Install seaborn
         pip install ${{ matrix.seaborn }}
+        # Fix numpy version
+        pip install numpy~=1.20
 
     - name: Run tests & coverage
       run: pytest --cov=starbars

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,49 @@
+name: Build and test BSB
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        matplotlib-version: ["3.6.0", "3.7.0", "3.8.0", "3.9.0"]
+        seaborn-version: ["0.13.0"]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Cache pip
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
+
+    - name: Install dependencies & self
+      run: |
+        # Install latest pip
+        pip install --upgrade pip
+        # Install starbars
+        pip install -e .[test]
+        # Install matplotlib
+        pip install matplotlib==${{ matrix.matplotlib-version }}
+        # Install seaborn
+        pip install seaborn==${{ matrix.seaborn-version }}
+
+    - name: Run tests & coverage
+      run: pytest --cov=starbars
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        matplotlib: ["matplotlib==3.6.0", "matplotlib==3.7.0"]
+        matplotlib: ["matplotlib==3.9.0"]
         seaborn: ["seaborn==0.13.0"]
     steps:
     - name: Checkout repository

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,4 @@
-name: Build and test BSB
+name: Build and test starbars
 
 on: [push, pull_request]
 
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        matplotlib: ["matplotlib==3.5.0", "matplotlib==3.6.0", "matplotlib==3.7.0"]
+        matplotlib: ["matplotlib==3.6.0", "matplotlib==3.7.0"]
         seaborn: ["seaborn==0.13.0"]
     steps:
     - name: Checkout repository

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        matplotlib-version: ["matplotlib==3.6.0", "matplotlib==3.7.0", "matplotlib==3.8.0", "matplotlib==3.9.0"]
-        seaborn-version: ["seaborn==0.13.0"]
+        matplotlib: ["matplotlib==3.6.0", "matplotlib==3.7.0", "matplotlib==3.8.0", "matplotlib==3.9.0"]
+        seaborn: ["seaborn==0.13.0"]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        matplotlib: ["matplotlib==3.6.0", "matplotlib==3.7.0", "matplotlib==3.8.0", "matplotlib==3.9.0"]
+        matplotlib: ["matplotlib==3.4.0", "matplotlib==3.5.0", "matplotlib==3.6.0", "matplotlib==3.7.0"]
         seaborn: ["seaborn==0.13.0"]
     steps:
     - name: Checkout repository

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         matplotlib: ["matplotlib==3.9.0"]
         seaborn: ["seaborn==0.13.0"]
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ docs = [
     "matplotlib~=3.9"
 ]
 test = [
+    "pytest",
     "pandas",
     "seaborn",
     "scipy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ docs = [
     "sphinx~=7.0",
     "matplotlib~=3.9"
 ]
+test = [
+    "pandas",
+    "seaborn",
+    "scipy"
+]
 
 [project.urls]
 Home = "https://github.com/elide-b/starbars"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ docs = [
 ]
 test = [
     "pytest",
+    "pytest-cov",
     "pandas",
     "seaborn",
     "scipy"

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,5 +1,7 @@
 import glob
+import os
 from pathlib import Path
+import importlib.util
 
 import pytest
 
@@ -8,7 +10,11 @@ import pytest
     "example", glob.glob(str(Path(__file__).parent.parent / "examples" / "*.py"))
 )
 def test_example_runnable(example):
-    # Load the example file
-    module = compile(open(example).read(), "test", "exec")
-    # Execute it to see if it throws any errors
-    exec(module)
+    # Load the example file as the starbars.__tests__.{name} module
+    name = example.split(os.sep)[-1].split(".")[0]
+    modname = f"starbars.__tests__.{name}"
+    spec = importlib.util.spec_from_file_location(modname, example)
+    module = importlib.util.module_from_spec(spec)
+
+    # Execute the example file
+    spec.loader.exec_module(module)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,14 @@
+import glob
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "example", glob.glob(str(Path(__file__).parent.parent / "examples" / "*.py"))
+)
+def test_example_runnable(example):
+    # Load the example file
+    module = compile(open(example).read(), "test", "exec")
+    # Execute it to see if it throws any errors
+    exec(module)


### PR DESCRIPTION
Hi, I've added the basic structure to run unit tests during CI.

The only test that I've added tests that all the files in the example folder are runnable without errors, for several supported `matplotlib` and `seaborn` versions.

The CI run also revealed that `starbars` has the following minimum version requirements:

* Python 3.9+
* matplotlib 3.9.0+
* seaborn 0.13.0+