### PR TITLE
Better stacking

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = "starbars"
 copyright = "2024, Elide Brunelli"
 author = "Elide Brunelli"
-release = "3.0.0"
+release = "3.1.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/starbars/__init__.py
+++ b/starbars/__init__.py
@@ -31,6 +31,7 @@ def draw_annotation(
     color="k",
     text_args=None,
     line_args=None,
+    h_gap=0.03,
 ):
     """
     Draw statistical significance bars and p-value labels between chosen pairs of columns on existing plots.
@@ -113,6 +114,7 @@ def draw_annotation(
             coords_to_px,
             px_ax,
             tip_length,
+            h_gap,
             px_to_coords,
             text_distance,
             bar_gap,
@@ -166,6 +168,7 @@ def calculate_bar(
     coords_to_px,
     px_ax,
     tip_length,
+    h_gap,
     px_to_coords,
     text_distance,
     bar_gap,
@@ -177,8 +180,8 @@ def calculate_bar(
     if label == "ns" and not ns_show:
         return
 
-    box1_px = coords_to_px((box1_pos, annot))[+(not annot_axis)]
-    box2_px = coords_to_px((box2_pos, annot))[+(not annot_axis)]
+    box1_px = coords_to_px((box1_pos + h_gap / 2, annot))[+(not annot_axis)]
+    box2_px = coords_to_px((box2_pos - h_gap / 2, annot))[+(not annot_axis)]
     annot_px = coords_to_px((box1_pos, annot))[annot_axis]
 
     bar_box = [box1_px, box1_px, box2_px, box2_px]

--- a/starbars/__init__.py
+++ b/starbars/__init__.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 
 from ._utils import pvalue_to_asterisks, get_positions, get_starbars_logger, find_level
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 
 
 DEBUG = bool(os.environ.get("DEBUG_STARBARS", False))

--- a/starbars/_utils.py
+++ b/starbars/_utils.py
@@ -148,7 +148,7 @@ def find_level(ax, annotations, mode):
         annotations,
         key=lambda x: (
             min(get_positions(ax, x[0], x[1], mode)),
-            -abs(
+            abs(
                 get_positions(ax, x[0], x[1], mode)[1]
                 - get_positions(ax, x[0], x[1], mode)[0]
             ),

--- a/starbars/_utils.py
+++ b/starbars/_utils.py
@@ -120,3 +120,22 @@ def get_starbars_logger(level):
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
     return logger
+
+
+def create_coordinate_transformer(ax, mode, inverse=False):
+    if inverse:
+        transformation = lambda *args: ax.transData.inverted().transform(*args)
+    else:
+        transformation = lambda *args: ax.transData.transform(*args)
+
+    if mode == "vertical":
+
+        def coords_to_px(coords):
+            return transformation(coords)
+
+    else:
+
+        def coords_to_px(coords):
+            return transformation(tuple(reversed(coords)))
+
+    return coords_to_px

--- a/starbars/_utils.py
+++ b/starbars/_utils.py
@@ -167,7 +167,7 @@ def find_level(ax, annotations, mode):
         # Find the first available level
         for level_index, level in enumerate(levels):
             if all(
-                box1_pos > existing_end or box2_pos < existing_start
+                box1_pos >= existing_end or box2_pos <= existing_start
                 for existing_start, existing_end, _, _ in level
             ):
                 levels[level_index].append((box1_pos, box2_pos, level_index, pvalue))


### PR DESCRIPTION
Sort the annotations left to right, and small to large, then put all the non-overlapping pieces on the same level to fix issues with rising diagonal stacking (closes #20)